### PR TITLE
ListItem Divider Optional Feature

### DIFF
--- a/src/ListItem.tsx
+++ b/src/ListItem.tsx
@@ -30,6 +30,7 @@ const ListItem: React.FC<ListItemProps> = ({
   leadingMode = 'icon',
   leading,
   trailing,
+  divider,
 
   pressEffect,
   pressEffectColor,
@@ -124,7 +125,9 @@ const ListItem: React.FC<ListItemProps> = ({
           </View>
         )}
       </View>
-      <Divider leadingInset={leading ? (leadingMode === 'icon' ? 56 : leadingMode === 'avatar' ? 88 : 116) : 16} />
+      {divider && (
+        <Divider leadingInset={leading ? (leadingMode === 'icon' ? 56 : leadingMode === 'avatar' ? 88 : 116) : 16} />
+      )}
     </Pressable>
   );
 };

--- a/src/ListItem.tsx
+++ b/src/ListItem.tsx
@@ -12,6 +12,7 @@ export interface ListItemProps extends Omit<SurfaceProps, 'hitSlop'>, Omit<Press
   secondaryText?: string;
 
   overline?: string;
+  divider?: Boolean;
 
   meta?: string;
 


### PR DESCRIPTION
fixes: https://github.com/yamankatby/react-native-material/issues/44

This is so important.

I can use ListItem for Drawer Navigation and they look ugly with the divider below them. And with this option, you can opt to use it or not.